### PR TITLE
Break/Decode Game Info Request from Client GetCurrentGames

### DIFF
--- a/PlayFabSDK/PluginFiles/PlayFab/PlayFab.uplugin
+++ b/PlayFabSDK/PluginFiles/PlayFab/PlayFab.uplugin
@@ -1,23 +1,28 @@
 {
-    "FileVersion": 3,
-    "FriendlyName": "PlayFabAllSDK",
-    "Version": 0,
-    "EngineVersion" : "4.16.3",
-    "VersionName": "0.0.170925",
-    "CreatedBy": "PlayFab and Joshua Lyons",
-    "CreatedByURL": "https://playfab.com/",
-    "DocsURL": "https://api.playfab.com/",
-    "SupportURL": "https://community.playfab.com/index.html",
-    "Category": "PlayFab",
-    "Description": "PlayFab CPP SDK for Unreal Engine 4. Current API version: 0.0.170925",
-    "WhitelistPlatforms": [ "Win64", "Win32", "Mac", "IOS", "Android" ],
-    "_MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/c048608baf4a404ba15121b26e3740dc",
-    "Modules" :
-    [
-        {
-            "Name": "PlayFab",
-            "Type": "Runtime",
-            "LoadingPhase": "PreDefault"
-        },
-    ]
+  "FileVersion": 3,
+  "FriendlyName": "PlayFabAllSDK",
+  "Version": 0,
+  "EngineVersion": "4.17.0",
+  "VersionName": "0.0.170925",
+  "CreatedBy": "PlayFab and Joshua Lyons",
+  "CreatedByURL": "https://playfab.com/",
+  "DocsURL": "https://api.playfab.com/",
+  "SupportURL": "https://community.playfab.com/index.html",
+  "Category": "PlayFab",
+  "Description": "PlayFab CPP SDK for Unreal Engine 4. Current API version: 0.0.170925",
+  "WhitelistPlatforms": [ "Win64", "Win32", "Mac", "IOS", "Android" ],
+  "_MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/c048608baf4a404ba15121b26e3740dc",
+  "Modules": [
+    {
+      "Name": "PlayFab",
+      "Type": "Runtime",
+      "LoadingPhase": "PreDefault"
+    }
+  ],
+  "Plugins": [
+    {
+      "Name": "OnlineSubsystemUtils",
+      "Enabled": true
+    }
+  ]
 }

--- a/PlayFabSDK/PluginFiles/PlayFab/Source/PlayFab/Classes/PlayFabClientModelDecoder.h
+++ b/PlayFabSDK/PluginFiles/PlayFab/Source/PlayFab/Classes/PlayFabClientModelDecoder.h
@@ -324,6 +324,10 @@ public:
     UFUNCTION(BlueprintCallable, Category = "PlayFab | Client | Matchmaking Models")
         static FClientCurrentGamesResult decodeCurrentGamesResultResponse(UPlayFabJsonObject* response);
 
+	/** Decode the GameInfoResult response object*/
+	UFUNCTION(BlueprintCallable, Category = "PlayFab | Client | Matchmaking Models")
+		static FClientGameInfoResult decodeGameInfoResultResponse(UPlayFabJsonObject* response);
+
     /** Decode the GameServerRegionsResult response object*/
     UFUNCTION(BlueprintCallable, Category = "PlayFab | Client | Matchmaking Models")
         static FClientGameServerRegionsResult decodeGameServerRegionsResultResponse(UPlayFabJsonObject* response);

--- a/PlayFabSDK/PluginFiles/PlayFab/Source/PlayFab/Classes/PlayFabClientModels.h
+++ b/PlayFabSDK/PluginFiles/PlayFab/Source/PlayFab/Classes/PlayFabClientModels.h
@@ -1711,6 +1711,43 @@ public:
 };
 
 USTRUCT(BlueprintType)
+struct FClientGameInfoResult
+{
+	GENERATED_USTRUCT_BODY()
+public:
+	/** version identifier of the game server executable binary being run */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Matchmaking Models")
+		FString BuildVersion;
+	/** time when Game Server Instance is currently scheduled to end */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Matchmaking Models")
+		FString EndTime;
+	/** unique identifier of the lobby  */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Matchmaking Models")
+		FString LobbyId;
+	/** game mode for this Game Server Instance */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Matchmaking Models")
+		FString Mode;
+	/** array of unique PlayFab identifiers for users currently connected to this Game Server Instance */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Matchmaking Models")
+		FString Players;
+	/** region in which the Game Server Instance is running */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Matchmaking Models")
+		ERegion Region;
+	/** IP address for this Game Server Instance */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Matchmaking Models")
+		FString ServerAddress;
+	/** communication port for this Game Server Instance */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Matchmaking Models")
+		int32 ServerPort = 0;
+	/** time when the Game Server Instance was created */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Matchmaking Models")
+		FString StartTime;
+	/** unique identifier of the Game Server Instance for this lobby */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PlayFab | Client | Matchmaking Models")
+		FString TitleId;
+};
+
+USTRUCT(BlueprintType)
 struct FClientGameServerRegionsRequest
 {
     GENERATED_USTRUCT_BODY()

--- a/PlayFabSDK/PluginFiles/PlayFab/Source/PlayFab/Private/PlayFabClientModelDecoder.cpp
+++ b/PlayFabSDK/PluginFiles/PlayFab/Source/PlayFab/Private/PlayFabClientModelDecoder.cpp
@@ -687,6 +687,25 @@ FClientCurrentGamesResult UPlayFabClientModelDecoder::decodeCurrentGamesResultRe
     return tempStruct;
 }
 
+FClientGameInfoResult UPlayFabClientModelDecoder::decodeGameInfoResultResponse(UPlayFabJsonObject* response)
+{
+	// Temp ustruct
+	FClientGameInfoResult tempStruct;
+
+	tempStruct.BuildVersion = !(response->HasField("BuildVersion")) ? TEXT("") : response->GetStringField("BuildVersion");
+	tempStruct.EndTime = !(response->HasField("EndTime")) ? TEXT("") : response->GetStringField("EndTime");
+	tempStruct.LobbyId = !(response->HasField("LobbyId")) ? TEXT("") : response->GetStringField("LobbyId");
+	tempStruct.Mode = !(response->HasField("Mode")) ? TEXT("") : response->GetStringField("Mode");
+	tempStruct.Players = !(response->HasField("Players")) ? TEXT("") : FString::Join(response->GetStringArrayField("Players"), TEXT(","));
+	GetEnumValueFromString<ERegion>(TEXT("ERegion"), response->GetStringField("Region"), tempStruct.Region);
+	tempStruct.ServerAddress = !(response->HasField("ServerAddress")) ? TEXT("") : response->GetStringField("ServerAddress");
+	tempStruct.ServerPort = !(response->HasField("ServerPort")) ? 0 : int(response->GetNumberField("ServerPort"));
+	tempStruct.StartTime = !(response->HasField("StartTime")) ? TEXT("") : response->GetStringField("StartTime");
+	tempStruct.TitleId = !(response->HasField("TitleId")) ? TEXT("") : response->GetStringField("TitleId");
+
+	return tempStruct;
+}
+
 FClientGameServerRegionsResult UPlayFabClientModelDecoder::decodeGameServerRegionsResultResponse(UPlayFabJsonObject* response)
 {
     // Temp ustruct


### PR DESCRIPTION
As discussed in forum ( https://community.playfab.com/questions/14314/ue4-blueprint-decodegetmatchmakergameinforesult.html?childToView=14837#comment-14837 )

Also updated plugin file to reflect compatibility with 4.17 (also compatible with 4.18 thus far) as well as listing the dependency on the "OnlineSubsystemUtils" to remove the irritating message.